### PR TITLE
Install OVS SELinux policy package

### DIFF
--- a/ovn-3node/build_ovn
+++ b/ovn-3node/build_ovn
@@ -33,5 +33,6 @@ sudo rpm -i ${OVN_PKG_DIR}/python*-openvswitch-2*.rpm \
             ${OVN_PKG_DIR}/openvswitch-ovn-common-2*.rpm \
             ${OVN_PKG_DIR}/openvswitch-ovn-host-2*.rpm \
             ${OVN_PKG_DIR}/openvswitch-ovn-central-2*.rpm \
+            $(compgen -G "${OVN_PKG_DIR}/openvswitch-selinux-policy-2*.rpm") \
     || { echo >&2 "$@"; echo >&2 "ERROR: failed to install packages"; exit 1; }
 


### PR DESCRIPTION
Since v2.8.0 ovs-vswitchd and ovsdb-server run as non-root user and
need a dedicated SELinux policy to override the distribution's policy.

See Documentation/howto/selinux.rst for more info.